### PR TITLE
Update actions/cache@v4 to v5 for Node 24 compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,14 +30,14 @@ runs:
     # Cache the Flutter SDK
     - if: ${{ inputs.cache-sdk == 'true' }}
       name: Configure Flutter SDK cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ runner.tool_cache }}/flutter
         key: flutter-action-setup-flutter-sdk-${{ runner.os }}-${{ inputs.version }}-${{ runner.arch }}-${{ inputs.channel }}
     # Cache the pub dependencies
     - if: ${{ inputs.cache == 'true' }}
       name: Configure pub dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/flutter/pub-cache
         key: flutter-action-setup-flutter-${{ inputs.cache-key }}-pub-cache-${{ runner.os }}-${{ inputs.version }}-${{ runner.arch }}-${{ inputs.channel }}


### PR DESCRIPTION
## Summary

Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026. `actions/cache@v4` uses Node 20, while v5 uses Node 24.

This PR updates the `actions/cache` dependency from v4 to v5 to ensure compatibility with the upcoming Node.js 24 requirement.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/